### PR TITLE
Add Google Sheets vocabulary learning experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.0.0'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.1'
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,28 +1,46 @@
-== README
+= Lexicon Coach
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+Lexicon Coach is a simple Rails application that turns a Google Sheet into a personal English vocabulary trainer. Add new words and phrases to the spreadsheet you already maintain, sync them into the app and review them through a searchable library and flashcard-style study mode.
 
-Things you may want to cover:
+== Prerequisites
 
-* Ruby version
+* Ruby (the container ships with Ruby 3.4.x)
+* Bundler
+* SQLite (for development and test)
 
-* System dependencies
+== Setup
 
-* Configuration
+1. Install gems with `bundle install`.
+2. Run `bundle exec rake db:migrate` to create the database tables.
+3. Start the server with `bundle exec rails server` and visit `http://localhost:3000`.
 
-* Database creation
+== Connecting a Google Sheet
 
-* Database initialization
+The importer expects a CSV export of your sheet. The easiest approach is to publish the sheet to the web (`File → Share → Publish to the web → CSV`). Copy the URL that ends with `export?format=csv`.
 
-* How to run the test suite
+You can either paste this URL into the sync form on the home page each time or set the `GOOGLE_SHEET_CSV_URL` environment variable.
 
-* Services (job queues, cache servers, search engines, etc.)
+=== Column mapping
 
-* Deployment instructions
+By default the importer looks for the following header names:
 
-* ...
+* `Term`
+* `Translation`
+* `Example`
+* `Notes`
 
+If your sheet uses different headers use the “Advanced column mapping” section in the sync form to specify the names. The importer will update existing entries (matched by the term) and add new ones automatically.
 
-Please feel free to use a different markup language if you do not plan to run
-<tt>rake doc:app</tt>.
+== Studying vocabulary
+
+Open the “Study” page to get a random flashcard. Use the buttons to reveal the translation, show additional context and move on to another word. Every time you press “Sync now” the latest version of your spreadsheet is reflected in the app.
+
+== Tests
+
+Run the test suite with:
+
+```
+bundle exec rake test
+```
+
+Some of the legacy gems in this project were written for Ruby 2.0 and may not install cleanly on modern Ruby versions. If bundler fails you may need to upgrade the dependencies or run the application inside a Ruby 2.0 compatible environment.

--- a/app/assets/javascripts/vocabulary_entries.js
+++ b/app/assets/javascripts/vocabulary_entries.js
@@ -1,0 +1,51 @@
+(function() {
+  function handleFlashcard() {
+    var $container = $('.vocabulary-study');
+    if (!$container.length) { return; }
+
+    var $translation = $container.find('[data-role="translation"]');
+    var $contextSections = $container.find('[data-role="example"], [data-role="notes"]');
+    var $toggleTranslation = $container.find('[data-action="toggle-translation"]');
+    var $toggleContext = $container.find('[data-action="toggle-context"]');
+
+    $toggleTranslation.off('click.lexicon').on('click.lexicon', function(event) {
+      event.preventDefault();
+      toggleSection($translation, $(this), 'Reveal translation', 'Hide translation');
+    });
+
+    $toggleContext.off('click.lexicon').on('click.lexicon', function(event) {
+      event.preventDefault();
+      if (!$contextSections.length) { return; }
+
+      var anyVisible = false;
+      $contextSections.each(function() {
+        if (!$(this).hasClass('is-hidden')) { anyVisible = true; }
+      });
+
+      if (anyVisible) {
+        $contextSections.addClass('is-hidden');
+        $(this).text('Show context');
+      } else {
+        $contextSections.removeClass('is-hidden');
+        $(this).text('Hide context');
+      }
+    });
+  }
+
+  function toggleSection($section, $button, showText, hideText) {
+    if (!$section.length) { return; }
+
+    if ($section.hasClass('is-hidden')) {
+      $section.removeClass('is-hidden');
+      if ($button && showText && hideText) { $button.text(hideText); }
+    } else {
+      $section.addClass('is-hidden');
+      if ($button && showText && hideText) { $button.text(showText); }
+    }
+  }
+
+  var events = ['ready', 'turbolinks:load', 'page:load'];
+  $.each(events, function(_, eventName) {
+    $(document).on(eventName, handleFlashcard);
+  });
+})();

--- a/app/assets/stylesheets/vocabulary_entries.css.scss
+++ b/app/assets/stylesheets/vocabulary_entries.css.scss
@@ -1,0 +1,104 @@
+.vocabulary-entries {
+  padding-top: 30px;
+
+  .page-header {
+    margin-top: 0;
+  }
+
+  .form-search {
+    margin-bottom: 20px;
+  }
+
+  .sync-panel {
+    margin-top: 25px;
+
+    .url-field {
+      width: 100%;
+      margin-bottom: 15px;
+
+      input {
+        width: 100%;
+      }
+    }
+
+    .advanced-options {
+      margin-top: 15px;
+
+      .advanced-toggle {
+        display: inline-block;
+        margin-bottom: 10px;
+      }
+    }
+  }
+
+  .vocabulary-table {
+    margin-top: 30px;
+
+    td.term {
+      font-weight: bold;
+    }
+
+    td.example,
+    td.notes {
+      min-width: 180px;
+    }
+  }
+}
+
+.vocabulary-entry-show {
+  padding-top: 30px;
+
+  .panel {
+    box-shadow: 0 3px 9px rgba(0, 0, 0, 0.1);
+  }
+
+  .study-actions {
+    margin-top: 20px;
+  }
+}
+
+.vocabulary-study {
+  padding-top: 30px;
+  text-align: center;
+
+  .flashcard {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    margin: 0 auto 30px;
+    max-width: 680px;
+    padding: 40px;
+  }
+
+  .flashcard-section + .flashcard-section {
+    margin-top: 20px;
+    border-top: 1px solid #f0f0f0;
+    padding-top: 20px;
+  }
+
+  .study-controls > * {
+    margin: 0 5px 10px;
+  }
+
+  .study-footer {
+    color: #777;
+  }
+}
+
+.flashcard-section.is-hidden {
+  display: none;
+}
+
+.navbar-spacer {
+  height: 70px;
+}
+
+.vocabulary-navbar {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e7e7e7;
+
+  .navbar-brand {
+    font-weight: 600;
+    letter-spacing: 0.5px;
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   def home
   end
-end
 
-def about 
-end 
+  def about
+  end
+end

--- a/app/controllers/vocabulary_entries_controller.rb
+++ b/app/controllers/vocabulary_entries_controller.rb
@@ -1,0 +1,48 @@
+class VocabularyEntriesController < ApplicationController
+  before_action :set_vocabulary_entry, only: [:show]
+
+  def index
+    @query = params[:query].to_s.strip
+    entries_scope = VocabularyEntry.order(:term)
+    entries_scope = entries_scope.search(@query)
+    @entries = entries_scope.paginate(page: params[:page], per_page: 25)
+  end
+
+  def show
+  end
+
+  def study
+    @entry = if params[:id].present?
+               VocabularyEntry.find_by(id: params[:id])
+             else
+               VocabularyEntry.random_entry
+             end
+
+    if @entry.nil?
+      redirect_to vocabulary_entries_path, alert: 'No vocabulary entries found. Please sync with your Google Sheet first.'
+    end
+  end
+
+  def sync
+    sheet_url = params[:sheet_url].presence || ENV['GOOGLE_SHEET_CSV_URL']
+    csv_payload = params[:csv_data]
+    importer = GoogleSheetVocabularyImporter.new(url: sheet_url, csv_data: csv_payload, column_mapping: column_mapping_params)
+    imported_count = importer.import
+
+    redirect_to vocabulary_entries_path, notice: "Imported #{imported_count} vocabulary entries from Google Sheets."
+  rescue GoogleSheetVocabularyImporter::MissingConfigurationError, GoogleSheetVocabularyImporter::ImportError => e
+    redirect_to vocabulary_entries_path, alert: e.message
+  end
+
+  private
+
+  def set_vocabulary_entry
+    @entry = VocabularyEntry.find(params[:id])
+  end
+
+  def column_mapping_params
+    return {} unless params[:column_mapping].present?
+
+    params.require(:column_mapping).permit(:term, :translation, :example, :notes)
+  end
+end

--- a/app/models/vocabulary_entry.rb
+++ b/app/models/vocabulary_entry.rb
@@ -1,0 +1,20 @@
+class VocabularyEntry < ActiveRecord::Base
+  validates :term, presence: true, uniqueness: true
+
+  scope :search, ->(query) do
+    if query.present?
+      sanitized_query = "%#{query.to_s.downcase.strip}%"
+      where('LOWER(term) LIKE :query OR LOWER(translation) LIKE :query', query: sanitized_query)
+    else
+      all
+    end
+  end
+
+  def self.random_entry
+    order('RANDOM()').first
+  end
+
+  def display_title
+    term
+  end
+end

--- a/app/services/google_sheet_vocabulary_importer.rb
+++ b/app/services/google_sheet_vocabulary_importer.rb
@@ -1,0 +1,94 @@
+require 'csv'
+require 'net/http'
+require 'uri'
+
+class GoogleSheetVocabularyImporter
+  class MissingConfigurationError < StandardError; end
+  class ImportError < StandardError; end
+
+  DEFAULT_COLUMN_MAPPING = {
+    term: 'Term',
+    translation: 'Translation',
+    example: 'Example',
+    notes: 'Notes'
+  }.freeze
+
+  attr_reader :url, :csv_data, :column_mapping
+
+  def initialize(url:, csv_data: nil, column_mapping: {})
+    @url = url
+    @csv_data = csv_data
+    @column_mapping = DEFAULT_COLUMN_MAPPING.merge(symbolize_keys(column_mapping))
+  end
+
+  def import
+    raise MissingConfigurationError, 'A Google Sheet CSV URL must be provided.' if csv_content.blank?
+
+    imported_count = 0
+
+    CSV.parse(csv_content, headers: true).each_with_index do |row, index|
+      term_value = cleaned_value(row[column_for(:term)])
+      next if term_value.blank?
+
+      entry = VocabularyEntry.find_or_initialize_by(term: term_value)
+      entry.translation = cleaned_value(row[column_for(:translation)])
+      entry.example = cleaned_value(row[column_for(:example)])
+      entry.notes = cleaned_value(row[column_for(:notes)])
+      entry.source_url = url if url.present?
+      entry.sheet_row_number = index + 2
+      entry.last_synced_at = Time.current
+
+      entry.save!
+      imported_count += 1
+    end
+
+    imported_count
+  rescue CSV::MalformedCSVError => e
+    raise ImportError, "The spreadsheet could not be parsed: #{e.message}"
+  rescue StandardError => e
+    raise ImportError, "The spreadsheet could not be imported: #{e.message}"
+  end
+
+  private
+
+  def csv_content
+    @csv_content ||= begin
+      if csv_data.present?
+        csv_data
+      elsif url.present?
+        fetch_from_url(url)
+      end
+    end
+  end
+
+  def fetch_from_url(target_url)
+    uri = URI.parse(target_url)
+    response = Net::HTTP.get_response(uri)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      raise ImportError, "Google Sheets responded with #{response.code}: #{response.message}"
+    end
+
+    body = response.body
+    body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+    body
+  rescue SocketError, Errno::ECONNREFUSED, Timeout::Error => e
+    raise ImportError, "The spreadsheet could not be downloaded: #{e.message}"
+  end
+
+  def column_for(key)
+    column_mapping[key] || DEFAULT_COLUMN_MAPPING[key]
+  end
+
+  def cleaned_value(value)
+    value.is_a?(String) ? value.strip : value
+  end
+
+  def symbolize_keys(hash)
+    return {} if hash.blank?
+
+    hash.each_with_object({}) do |(key, value), memo|
+      memo[key.to_sym] = value
+    end
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,66 +1,22 @@
-<nav class="navbar navbar-fixed-top navbar-default" role="navigation">
-  <div class="container">  <!-- Brand and toggle get grouped for better mobile display -->
+<nav class="navbar navbar-default navbar-fixed-top vocabulary-navbar" role="navigation">
+  <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
-     <!--   <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar">ddd</span>
-        <span class="icon-bar">ddd</span>
-        <span class="icon-bar">ddd</span> -->
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-vocabulary">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/">ЕЛЕКТРОННЕ БЮРО ОБМІНУ КВАРТИР  <span class="glyphicon glyphicon-refresh"></span>
-      </a>
+      <%= link_to 'Lexicon Coach', root_path, class: 'navbar-brand' %>
     </div>
 
-
-
-    <!-- Collect the nav links, forms, and other content for toggling -->
-    <div class="collapse navbar-collapse navbar-ex1-collapse">
-      <ul class="nav navbar-nav navbar-right nav-pills">
-
-
-
-
-          <li class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                РОЗДІЛИ <span class="caret"></span>
-            </a>
-              <ul class="dropdown-menu">
-                        <li><%= link_to "Home", root_path %></li>
-                        <li><%= link_to "About", about_path %></li>
-                        <li class = "active"><%= link_to "Переваги обміну", root_path %> </li>
-                        <li><%= link_to "Як працює сервіс", root_path %> </li>
-                        <li><%= link_to "Правові питання", root_path %> </li>
-                        <li><%= link_to "Тарифи", root_path %> </li>
-
-                        <li></li>
-
-              </ul>
-          </li>
-
-
-          <li>
-            <%= button_to new_variant_path, :class => "btn btn-default navbar-btn btn-warning", :method => :get  do %>
-                  <span class="glyphicon glyphicon-off"></span> Розмістити оголошення
-            <% end %>
-
-          </li>
-
-     <!--     <li><%= link_to "Home", root_path %></li>
-          <li><%= link_to "About", about_path %></li> -->
-          <li>
-              <% if user_signed_in? %>  
-                  <li><%= link_to current_user.email, edit_user_registration_path %></li>
-                  <li><%= link_to "Log out", destroy_user_session_path, method: :delete %></li>
-              <% else %>
-            <li><%= link_to "Sign in", new_user_session_path %>          </li>
-           
-              <% end %>          
-          </li>
-
+    <div class="collapse navbar-collapse" id="navbar-vocabulary">
+      <ul class="nav navbar-nav">
+        <li><%= link_to 'Vocabulary', vocabulary_entries_path %></li>
+        <li><%= link_to 'Study', study_vocabulary_entries_path %></li>
+        <li><%= link_to 'About', about_path %></li>
       </ul>
-    </div><!-- /.navbar-collapse -->
+    </div>
   </div>
 </nav>
-
-
-
+<div class="navbar-spacer"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Елекронне бюро обміну квартир</title>
+  <title>Lexicon Coach</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
@@ -12,9 +12,18 @@
 
      <%= render 'layouts/header' %>
 
-     <% flash.each do |name, msg| %>
-     		<%= content_tag(:div, msg, class: "alert alert-info") %>
-		 <% end %>
+     <% if flash.any? %>
+       <div class="container">
+         <% flash.each do |name, msg| %>
+           <% css_class = case name.to_sym
+                         when :notice then 'alert-success'
+                         when :alert then 'alert-danger'
+                         else 'alert-info'
+                         end %>
+           <%= content_tag(:div, msg, class: "alert #{css_class}") %>
+         <% end %>
+       </div>
+     <% end %>
 
 
           <%= yield %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,2 +1,27 @@
-<h1>About US</h1>
-<p>We are working on our One Month Rails Pinteresting app</p>
+<div class="container about-lexicon">
+  <div class="page-header">
+    <h1>About Lexicon Coach</h1>
+  </div>
+
+  <p class="lead">
+    Lexicon Coach turns a simple Google Sheet into a personal language laboratory. Collect new English words
+    and phrases in your spreadsheet and synchronise them here to review, search and study.
+  </p>
+
+  <h3>How it works</h3>
+  <ol>
+    <li>Create a Google Sheet with columns for the word or phrase, its translation, and any examples or notes.</li>
+    <li>Publish the sheet to the web or copy the CSV export link.</li>
+    <li>Paste the link into the sync form on the home page.</li>
+    <li>Use the study mode to practise flashcards generated from your latest entries.</li>
+  </ol>
+
+  <h3>Tips</h3>
+  <ul>
+    <li>Keep each row focused on one vocabulary item. Use the notes field for collocations, synonyms or grammar reminders.</li>
+    <li>Update the spreadsheet any time during the day—syncing is as simple as pressing the “Sync now” button.</li>
+    <li>For longer explanations, paste a short summary in the notes field so the flashcard stays concise.</li>
+  </ul>
+
+  <p>If you ever need to adjust the column names in the sheet, use the “Advanced column mapping” section on the sync form.</p>
+</div>

--- a/app/views/vocabulary_entries/_entry.html.erb
+++ b/app/views/vocabulary_entries/_entry.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td class="term">
+    <%= link_to entry.term, vocabulary_entry_path(entry) %>
+  </td>
+  <td class="translation"><%= entry.translation.presence || '—' %></td>
+  <td class="example"><%= simple_format(entry.example) if entry.example.present? %></td>
+  <td class="notes"><%= simple_format(entry.notes) if entry.notes.present? %></td>
+</tr>

--- a/app/views/vocabulary_entries/index.html.erb
+++ b/app/views/vocabulary_entries/index.html.erb
@@ -1,0 +1,109 @@
+<div class="container vocabulary-entries">
+  <div class="page-header">
+    <h1>Vocabulary Library</h1>
+    <p class="lead">Review everything you have collected in your Google Sheet.</p>
+  </div>
+
+  <% mapping_params = params[:column_mapping] || {} %>
+  <% mapping_params = mapping_params.to_unsafe_h if mapping_params.respond_to?(:to_unsafe_h) %>
+
+  <div class="row vocabulary-actions">
+    <div class="col-md-8">
+      <%= form_tag vocabulary_entries_path, method: :get, class: 'form-inline form-search' do %>
+        <div class="form-group">
+          <%= label_tag :query, 'Search vocabulary', class: 'sr-only' %>
+          <%= text_field_tag :query, @query, class: 'form-control input-lg', placeholder: 'Search words or translations' %>
+        </div>
+        <%= submit_tag 'Search', class: 'btn btn-primary btn-lg' %>
+        <% if @query.present? %>
+          <%= link_to 'Clear', vocabulary_entries_path, class: 'btn btn-default btn-lg' %>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="col-md-4 text-right">
+      <%= link_to 'Start studying', study_vocabulary_entries_path, class: 'btn btn-success btn-lg study-button' %>
+    </div>
+  </div>
+
+  <div class="panel panel-default sync-panel">
+    <div class="panel-heading">
+      <h3 class="panel-title">Synchronise with Google Sheets</h3>
+    </div>
+    <div class="panel-body">
+      <p class="help-block">
+        Paste the <strong>CSV export link</strong> from your Google Sheet and press <em>Sync now</em>.
+        You can publish a sheet to the web or copy the link from <code>File → Share → Publish to the web → CSV</code>.
+      </p>
+      <%= form_tag sync_vocabulary_entries_path, method: :post, class: 'form-inline sync-form' do %>
+        <div class="form-group form-group-lg url-field">
+          <%= label_tag :sheet_url, 'Google Sheet CSV URL', class: 'sr-only' %>
+          <%= text_field_tag :sheet_url, params[:sheet_url].presence || ENV['GOOGLE_SHEET_CSV_URL'], class: 'form-control input-lg', placeholder: 'https://docs.google.com/spreadsheets/d/.../export?format=csv' %>
+        </div>
+        <%= submit_tag 'Sync now', class: 'btn btn-info btn-lg' %>
+
+        <div class="advanced-options">
+          <a class="advanced-toggle" data-toggle="collapse" href="#column-mapping" aria-expanded="false" aria-controls="column-mapping">
+            Advanced column mapping
+          </a>
+          <div class="collapse" id="column-mapping">
+            <p class="help-block">Only change these fields if your sheet uses different column headers.</p>
+            <div class="row">
+              <div class="col-sm-3">
+                <%= label_tag 'column_mapping_term', 'Term column' %>
+                <%= text_field_tag 'column_mapping[term]', mapping_params[:term] || mapping_params['term'], class: 'form-control', placeholder: 'Term' %>
+              </div>
+              <div class="col-sm-3">
+                <%= label_tag 'column_mapping_translation', 'Translation column' %>
+                <%= text_field_tag 'column_mapping[translation]', mapping_params[:translation] || mapping_params['translation'], class: 'form-control', placeholder: 'Translation' %>
+              </div>
+              <div class="col-sm-3">
+                <%= label_tag 'column_mapping_example', 'Example column' %>
+                <%= text_field_tag 'column_mapping[example]', mapping_params[:example] || mapping_params['example'], class: 'form-control', placeholder: 'Example' %>
+              </div>
+              <div class="col-sm-3">
+                <%= label_tag 'column_mapping_notes', 'Notes column' %>
+                <%= text_field_tag 'column_mapping[notes]', mapping_params[:notes] || mapping_params['notes'], class: 'form-control', placeholder: 'Notes' %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @entries.present? %>
+    <div class="table-responsive">
+      <table class="table table-striped table-hover vocabulary-table">
+        <thead>
+          <tr>
+            <th>Term</th>
+            <th>Translation</th>
+            <th>Example</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @entries.each do |entry| %>
+            <%= render partial: 'entry', locals: { entry: entry } %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="text-center">
+      <% if defined?(BootstrapPagination::Rails) %>
+        <%= will_paginate @entries, renderer: BootstrapPagination::Rails %>
+      <% else %>
+        <%= will_paginate @entries %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="jumbotron">
+      <h2>Your vocabulary list is empty</h2>
+      <p>Synchronise with your Google Sheet to start building your personal dictionary.</p>
+      <p>
+        <%= link_to 'Sync now', '#column-mapping', class: 'btn btn-info btn-lg', data: { toggle: 'collapse' } %>
+        <%= link_to 'Start studying', study_vocabulary_entries_path, class: 'btn btn-success btn-lg' %>
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/vocabulary_entries/show.html.erb
+++ b/app/views/vocabulary_entries/show.html.erb
@@ -1,0 +1,47 @@
+<div class="container vocabulary-entry-show">
+  <ol class="breadcrumb">
+    <li><%= link_to 'Vocabulary', vocabulary_entries_path %></li>
+    <li class="active"><%= @entry.term %></li>
+  </ol>
+
+  <div class="panel panel-primary">
+    <div class="panel-heading">
+      <h2 class="panel-title"><%= @entry.term %></h2>
+    </div>
+    <div class="panel-body">
+      <% if @entry.translation.present? %>
+        <p class="translation"><strong>Translation:</strong> <%= @entry.translation %></p>
+      <% end %>
+
+      <% if @entry.example.present? %>
+        <div class="example">
+          <h4>Example</h4>
+          <%= simple_format(@entry.example) %>
+        </div>
+      <% end %>
+
+      <% if @entry.notes.present? %>
+        <div class="notes">
+          <h4>Notes</h4>
+          <%= simple_format(@entry.notes) %>
+        </div>
+      <% end %>
+
+      <dl class="metadata">
+        <% if @entry.sheet_row_number.present? %>
+          <dt>Sheet row</dt>
+          <dd><%= @entry.sheet_row_number %></dd>
+        <% end %>
+        <% if @entry.last_synced_at.present? %>
+          <dt>Last synced</dt>
+          <dd><%= l @entry.last_synced_at, format: :long %></dd>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+
+  <div class="study-actions">
+    <%= link_to 'Study another word', study_vocabulary_entries_path, class: 'btn btn-success btn-lg' %>
+    <%= link_to 'Back to vocabulary', vocabulary_entries_path, class: 'btn btn-default btn-lg' %>
+  </div>
+</div>

--- a/app/views/vocabulary_entries/study.html.erb
+++ b/app/views/vocabulary_entries/study.html.erb
@@ -1,0 +1,43 @@
+<% if @entry %>
+  <div class="container vocabulary-study" data-controller="flashcard">
+    <div class="page-header">
+      <h1>Study mode</h1>
+      <p class="lead">Practice a random word or phrase from your Google Sheet.</p>
+    </div>
+
+    <div class="flashcard" data-role="flashcard">
+      <div class="flashcard-section flashcard-term">
+        <h2><%= @entry.term %></h2>
+      </div>
+      <div class="flashcard-section flashcard-translation is-hidden" data-role="translation">
+        <h3>Translation</h3>
+        <p><%= @entry.translation.presence || 'No translation provided yet.' %></p>
+      </div>
+      <% if @entry.example.present? %>
+        <div class="flashcard-section flashcard-example is-hidden" data-role="example">
+          <h3>Example</h3>
+          <%= simple_format(@entry.example) %>
+        </div>
+      <% end %>
+      <% if @entry.notes.present? %>
+        <div class="flashcard-section flashcard-notes is-hidden" data-role="notes">
+          <h3>Notes</h3>
+          <%= simple_format(@entry.notes) %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="study-controls">
+      <button class="btn btn-primary btn-lg" data-action="toggle-translation">Reveal translation</button>
+      <% if @entry.example.present? || @entry.notes.present? %>
+        <button class="btn btn-default btn-lg" data-action="toggle-context">Show context</button>
+      <% end %>
+      <%= link_to 'Next word', study_vocabulary_entries_path, class: 'btn btn-success btn-lg' %>
+      <%= link_to 'View full entry', vocabulary_entry_path(@entry), class: 'btn btn-link btn-lg' %>
+    </div>
+
+    <div class="study-footer">
+      <p><strong>Tip:</strong> Keep the Google Sheet open in another tab to add new words. Every time you press <em>Sync now</em> on the library page your latest notes will appear here.</p>
+    </div>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module Kvarto
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    config.autoload_paths += %W(#{config.root}/app/services)
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,19 @@
 Rails.application.routes.draw do
 
+  resources :vocabulary_entries, only: [:index, :show] do
+    collection do
+      get :study
+      post :sync
+    end
+  end
+
   resources :pins
 
   resources :variants
 
   devise_for :users
 
- root "variants#index"
+  root "vocabulary_entries#index"
 
   get "about" => "pages#about"
   

--- a/db/migrate/20240705120000_create_vocabulary_entries.rb
+++ b/db/migrate/20240705120000_create_vocabulary_entries.rb
@@ -1,0 +1,17 @@
+class CreateVocabularyEntries < ActiveRecord::Migration
+  def change
+    create_table :vocabulary_entries do |t|
+      t.string :term, null: false
+      t.string :translation
+      t.text :example
+      t.text :notes
+      t.string :source_url
+      t.integer :sheet_row_number
+      t.datetime :last_synced_at
+
+      t.timestamps
+    end
+
+    add_index :vocabulary_entries, :term, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140525151415) do
+ActiveRecord::Schema.define(version: 20240705120000) do
 
   create_table "pins", force: true do |t|
     t.string   "name"
@@ -58,5 +58,19 @@ ActiveRecord::Schema.define(version: 20140525151415) do
   end
 
   add_index "variants", ["user_id"], name: "index_variants_on_user_id"
+
+  create_table "vocabulary_entries", force: true do |t|
+    t.string   "term",             null: false
+    t.string   "translation"
+    t.text     "example"
+    t.text     "notes"
+    t.string   "source_url"
+    t.integer  "sheet_row_number"
+    t.datetime "last_synced_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "vocabulary_entries", ["term"], name: "index_vocabulary_entries_on_term", unique: true
 
 end

--- a/test/controllers/vocabulary_entries_controller_test.rb
+++ b/test/controllers/vocabulary_entries_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class VocabularyEntriesControllerTest < ActionController::TestCase
+  setup do
+    @entry = vocabulary_entries(:sample)
+  end
+
+  test 'should get index' do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:entries)
+  end
+
+  test 'should show entry' do
+    get :show, id: @entry
+    assert_response :success
+  end
+
+  test 'should get study view when entries exist' do
+    get :study
+    assert_response :success
+    assert assigns(:entry)
+  end
+
+  test 'should redirect study when no entries available' do
+    VocabularyEntry.delete_all
+    get :study
+    assert_redirected_to vocabulary_entries_path
+    assert_equal 'No vocabulary entries found. Please sync with your Google Sheet first.', flash[:alert]
+  end
+
+  test 'should sync from csv payload' do
+    VocabularyEntry.delete_all
+    csv_payload = "Term,Translation\nFocus,концентрація\n"
+
+    assert_difference 'VocabularyEntry.count', 1 do
+      post :sync, csv_data: csv_payload
+    end
+
+    assert_redirected_to vocabulary_entries_path
+    assert_equal 'Imported 1 vocabulary entries from Google Sheets.', flash[:notice]
+  end
+end

--- a/test/fixtures/vocabulary_entries.yml
+++ b/test/fixtures/vocabulary_entries.yml
@@ -1,0 +1,5 @@
+sample:
+  term: Hello
+  translation: Привіт
+  example: Hello there!
+  notes: Greeting used when meeting someone.

--- a/test/models/vocabulary_entry_test.rb
+++ b/test/models/vocabulary_entry_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class VocabularyEntryTest < ActiveSupport::TestCase
+  def setup
+    @sample = vocabulary_entries(:sample)
+  end
+
+  test 'is invalid without a term' do
+    entry = VocabularyEntry.new(translation: 'Test')
+    assert entry.invalid?
+    assert_includes entry.errors[:term], "can't be blank"
+  end
+
+  test 'enforces uniqueness on term' do
+    duplicate = VocabularyEntry.new(term: @sample.term)
+    assert duplicate.invalid?
+    assert_includes duplicate.errors[:term], 'has already been taken'
+  end
+
+  test 'search finds matches in term and translation' do
+    entry = VocabularyEntry.create!(term: 'Sunflower', translation: 'соняшник')
+    assert_includes VocabularyEntry.search('sun'), entry
+    assert_includes VocabularyEntry.search('сон'), entry
+  end
+
+  test 'search returns all entries when query blank' do
+    expected_ids = VocabularyEntry.order(:term).map(&:id)
+    actual_ids = VocabularyEntry.search(nil).order(:term).map(&:id)
+    assert_equal expected_ids, actual_ids
+  end
+end

--- a/test/services/google_sheet_vocabulary_importer_test.rb
+++ b/test/services/google_sheet_vocabulary_importer_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class GoogleSheetVocabularyImporterTest < ActiveSupport::TestCase
+  SAMPLE_CSV = <<-CSV
+Term,Translation,Example,Notes
+Hello,Привіт,Hello there!,Greeting someone with a smile.
+CSV
+
+  test 'imports new vocabulary entries' do
+    importer = GoogleSheetVocabularyImporter.new(url: 'http://example.com', csv_data: SAMPLE_CSV)
+
+    assert_difference 'VocabularyEntry.count', 1 do
+      importer.import
+    end
+
+    entry = VocabularyEntry.find_by(term: 'Hello')
+    assert_not_nil entry
+    assert_equal 'Привіт', entry.translation
+    assert_equal 'Hello there!', entry.example
+    assert_equal 'Greeting someone with a smile.', entry.notes
+    assert_equal 2, entry.sheet_row_number
+    assert_equal 'http://example.com', entry.source_url
+    assert_not_nil entry.last_synced_at
+  end
+
+  test 'updates existing entries when the term already exists' do
+    csv_data = <<-CSV
+Term,Translation,Example,Notes
+Hello,Привіт!,Updated example,Updated notes
+CSV
+
+    importer = GoogleSheetVocabularyImporter.new(url: 'http://example.com', csv_data: csv_data)
+
+    assert_no_difference 'VocabularyEntry.count' do
+      importer.import
+    end
+
+    entry = VocabularyEntry.find_by(term: 'Hello')
+    assert_equal 'Привіт!', entry.translation
+    assert_equal 'Updated example', entry.example
+    assert_equal 'Updated notes', entry.notes
+  end
+
+  test 'supports custom column mapping' do
+    csv_data = <<-CSV
+Word,Meaning
+Sunshine,сонце
+CSV
+
+    importer = GoogleSheetVocabularyImporter.new(
+      url: 'http://example.com',
+      csv_data: csv_data,
+      column_mapping: { term: 'Word', translation: 'Meaning' }
+    )
+
+    importer.import
+
+    entry = VocabularyEntry.find_by(term: 'Sunshine')
+    assert_not_nil entry
+    assert_equal 'сонце', entry.translation
+  end
+
+  test 'raises an error when no URL or data is provided' do
+    importer = GoogleSheetVocabularyImporter.new(url: nil, csv_data: '')
+
+    assert_raises GoogleSheetVocabularyImporter::MissingConfigurationError do
+      importer.import
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- introduce a VocabularyEntry model and GoogleSheetVocabularyImporter to pull words, translations, examples and notes from a Google Sheet CSV export
- add dedicated vocabulary library, detail and study mode interfaces with Bootstrap styling and flashcard interactions
- refresh the layout/navigation and documentation to describe the new English-learning workflow

## Testing
- bundle install *(fails: Bundler cannot download gems in the execution environment and returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c836c03b8c8323bdf299ead5367b1b